### PR TITLE
[RPD-74] Remove `zenml up` from setup.sh

### DIFF
--- a/recommendation/setup.sh
+++ b/recommendation/setup.sh
@@ -43,10 +43,9 @@ echo "Setting up ZenML..."
     az acr login --name="$acr_registry_name"
 
     zenml init
-    zenml up
     
-    zenml secret create az_secret --connection_string="$zenml_connection_string"
     zenml connect --url="$zenserver_url" --username="$zenserver_username" --password="$zenserver_password" --no-verify-ssl
+    zenml secret create az_secret --connection_string="$zenml_connection_string"
     zenml container-registry register acr_registry -f azure --uri="$acr_registry_uri"
     zenml experiment-tracker register mlflow_experiment_tracker -f mlflow --tracking_uri="$mlflow_tracking_url" --tracking_username=username --tracking_password=password
     zenml artifact-store register az_store -f azure --path="$zenml_storage_path" --authentication_secret=az_secret


### PR DESCRIPTION
The example pipeline will fail to run as zenml up is included in main which will start a local zen server. The order of creating the secret should also be after connected to remote zen server.

This PR removes the `zenml up` command in `setup.sh` and connect to remote zen server before creating a secret.