### PR TITLE
[RPD-92] Create a CI for LLM example

### DIFF
--- a/.github/workflows/ci-llm.yml
+++ b/.github/workflows/ci-llm.yml
@@ -63,5 +63,5 @@ jobs:
       - name: Run tests with pytest
         run: |
           source venv/bin/activate
-
-          python -m pytest llm/tests/
+          cd llm
+          python -m pytest tests/

--- a/.github/workflows/ci-recommendation.yml
+++ b/.github/workflows/ci-recommendation.yml
@@ -65,5 +65,5 @@ jobs:
       - name: Run tests with pytest
         run: |
           source venv/bin/activate
-
-          python -m pytest recommendation/tests/
+          cd recommendation
+          python -m pytest tests/


### PR DESCRIPTION
In this PR, we create a separate CI workflow for LLM example. We will experiment with different approach to the existing recommendation CI workflow such that the CI job is triggered only if changed are made to particular folder.

-  First Approach : Github Action Workflow [provides](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-paths) a argument `path` that we can set to trigger a job based on which files are changed. 

- Second Approach: We use [paths-filter](https://github.com/dorny/paths-filter) github action that provides a trigger for when a particular folder is changed and runs the particular job only when files corresponding to that job are changed.

The screenshot below summarizes our intention.

Example 1 : Recommendation Example CI

To trigger this workflow, I changed one of the files in `recommendation` example and only job for recommendation run. The job for `llm` example was skipped.

![image](https://user-images.githubusercontent.com/10743098/232047779-b1d466f2-1670-4e88-af0c-4bd6790fba8d.png)

Example 2 : LLM Example CI

To trigger this workflow, we run the workflow against PR#10 where only changes to LLM example are present.

![image](https://user-images.githubusercontent.com/10743098/232051555-38b741ff-0560-4aea-b7cd-a9a3eef174c7.png)

> Test for that branch are failing which will be fixed in the same branch. They seems to be related to python modules with error `ModuleNotFoundError: No module named 'steps'`.
