### PR TITLE
[RPD-71] Improve Error Handling in Example Repository Setup

### DIFF
--- a/recommendation/setup.sh
+++ b/recommendation/setup.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
-# echo "Installing example requirements (see requirements.txt)..."
-# {
-#     pip install -r requirements.txt
+echo "Installing example requirements (see requirements.txt)..."
+{
+    pip install -r requirements.txt
     
-#     zenml integration install mlflow azure kubernetes seldon -y
-# } >> setup_out.log
+    zenml integration install mlflow azure kubernetes seldon -y
+} >> setup_out.log
 
-# if [[ ! -f .matcha/infrastructure/matcha.state ]]
-# then
-#     echo "Error: The file .matcha/infrastructure/matcha.state does not exist!"
-#     echo "Ensure that you have run 'matcha provision' in this directory and all cloud resources have been provisioned."
-#     exit 1
-# fi
+if [[ ! -f .matcha/infrastructure/matcha.state ]]
+then
+    echo "Error: The file .matcha/infrastructure/matcha.state does not exist!"
+    echo "Ensure that you have run 'matcha provision' in this directory and all cloud resources have been provisioned."
+    exit 1
+fi
 
 
 get_state_value() {


### PR DESCRIPTION
The current setup script for the example repository does not include any error handling to check whether components, stacks or pipelines etc.. already exist in the remote zenserver. 

This PR implement various error handling checks in `setup.sh` to improve the usability of the setup process.

Checks implemented in the PR:
- Whether all the required variables for ZenML have been set, (values obtain from `matcha.state`).
- Whether a stack name `recommendation_example_cloud_stack` has already been registered, removed if found.
- For each of the component for the recommendation example stack, whether they have already been registered with the same name, remove if found.