### PR TITLE
[RPD-94] Add the `matcha run deploy` changes to the example repo

### DIFF
--- a/recommendation/run.py
+++ b/recommendation/run.py
@@ -44,17 +44,23 @@ def run_deployment_pipeline():
     
 @click.command()
 @click.option("--train", "-t", is_flag=True, help="Run training pipeline")
-def main(train: bool):
+@click.option("--deploy", "-d", is_flag=True, help="Run the deployment pipeline")
+def main(train: bool, deploy: bool):
     """Run all pipelines.
     
     args:
         train (bool): Flag for running the training pipeline.
+        deploy (bool): Flag for running the deployment pipeline.
     """
     if train:
         logger.info("Running recommendation training pipeline.")
         run_recommendation_pipeline()
     
-    if not train:
+    if deploy:
+        logger.info("Running deployment pipeline.")
+        run_deployment_pipeline()
+    
+    if (not train) and (not deploy):
         logger.info("Running recommendation training pipeline.")
         run_recommendation_pipeline()
         


### PR DESCRIPTION
This PR adds a flag` --deploy`

Usage:
```bash
python run.py --deploy
```

To run the deployment pipeline. This is required by the `matcha run deploy` command.