### PR TITLE
[RPD-135] Update matcha-example setup.sh with new --show-sensitive flag

### DIFF
--- a/llm/setup.sh
+++ b/llm/setup.sh
@@ -43,7 +43,7 @@ fi
 function get_state_value() {
     resource_name=$1
     property=$2
-    json_string=$(matcha get $resource_name $property --output json)
+    json_string=$(matcha get $resource_name $property --output json --show-sensitive)
     value=$(echo $json_string | jq -r '."'$resource_name'"."'$property'"')
     echo $value
 }

--- a/recommendation/setup.sh
+++ b/recommendation/setup.sh
@@ -43,7 +43,7 @@ fi
 function get_state_value() {
     resource_name=$1
     property=$2
-    json_string=$(matcha get $resource_name $property --output json)
+    json_string=$(matcha get $resource_name $property --output json --show-sensitive)
     value=$(echo $json_string | jq -r '."'$resource_name'"."'$property'"')
     echo $value
 }


### PR DESCRIPTION
Since RPD-122 and RPD-127, sensitive values are hidden by default and required users to pass in the --show-sensitive option to matcha get in order to retrieve the value of sensitive value. This PR update the setup.sh in matcha-example so that it can get and properly set up zenml with the correct value.

Both examples have been tested from the beginning following the readme.
