### PR TITLE
[RPD-139] Update documentation ready for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ matcha provision
 
 Once that's complete, dive into the example workflows!
 
-> You'll need the right level of permissions on your Azure account - see here.
+> You'll need the right level of permissions on your Azure account - see [here](https://fuzzylabs.github.io/matcha/azure-permissions/).
 
 ---
 

--- a/llm/README.md
+++ b/llm/README.md
@@ -2,7 +2,7 @@
 
 In this example, we'll show you how to use matcha to setup a default cloud environment on Azure and hook up a Large Language Model (LLM) for summarization pipeline to run on that environment.
 
-If you're wondering what on earth `matcha` is (besides the drink) then check out our main repository [here](https://github.com/fuzzylabs/matcha) and our [documentation](LINK) - don't forget to come back to try out this example!
+If you're wondering what on earth `matcha` is (besides the drink) then check out our main repository [here](https://github.com/fuzzylabs/matcha) and our [documentation](https://fuzzylabs.github.io/matcha/) - don't forget to come back to try out this example!
 
 ## 🚦 Getting Started
 

--- a/recommendation/README.md
+++ b/recommendation/README.md
@@ -2,7 +2,7 @@
 
 In this example, we'll show you how to use matcha to setup a default cloud environment on Azure and hook up a movie recommendation pipeline to run on that environment.
 
-If you're wondering what on earth `matcha` is (besides the drink) then check out our main repository [here](https://github.com/fuzzylabs/matcha) and our [documentation](LINK) - don't forget to come back to try out this example!
+If you're wondering what on earth `matcha` is (besides the drink) then check out our main repository [here](https://github.com/fuzzylabs/matcha) and our [documentation](https://fuzzylabs.github.io/matcha/) - don't forget to come back to try out this example!
 
 ## 🚦 Getting Started
 


### PR DESCRIPTION
This PR makes changes to the three readme's in this repository:

1. Removes the provision warning from both workflow readme's
2. Adds links to the individual examples in the main readme
3. Updates `pip install matcha` to `pip install matcha-ml`