### PR TITLE
[RPD-176] Remove dependency on jq for the examples

### DIFF
--- a/llm/setup.sh
+++ b/llm/setup.sh
@@ -1,33 +1,6 @@
 #!/bin/bash
 echo "Installing example requirements (see requirements.txt)..."
 {
-    # Install jq on macOS using Homebrew
-    if [[ "$(uname -s)" == "Darwin" ]]; then
-        if ! command -v brew &> /dev/null; then
-            echo "Error: Homebrew is not installed."
-            exit 1
-        fi
-
-        if ! command -v jq &> /dev/null; then
-            echo "Installing jq using Homebrew..."
-            brew install jq
-        fi
-    fi
-
-    # Install jq on Linux using APT
-    if [[ "$(uname -s)" == "Linux" ]]; then
-        if ! command -v apt-get &> /dev/null; then
-            echo "Error: APT is not available."
-            exit 1
-        fi
-
-        if ! command -v jq &> /dev/null; then
-            echo "Installing jq using APT..."
-            sudo apt-get update
-            sudo apt-get install -y jq
-        fi
-    fi
-
     pip install -r requirements.txt
     zenml integration install huggingface pytorch azure kubernetes seldon -y
 } >> setup_out.log
@@ -40,24 +13,27 @@ then
 fi
 
 
-function get_state_value() {
-    resource_name=$1
-    property=$2
-    json_string=$(matcha get $resource_name $property --output json --show-sensitive)
-    value=$(echo $json_string | jq -r '."'$resource_name'"."'$property'"')
+get_state_value() {
+    key=$1
+    value=$(sed -n 's/.*"'$key'": "\(.*\)".*/\1/p' .matcha/infrastructure/matcha.state)
+    if [[ -z $value ]]; then
+        echo "Error: The value for '$key' is not found in .matcha/infrastructure/matcha.state!"
+        exit 1
+    fi
     echo $value
 }
 
-zenml_storage_path=$(get_state_value pipeline storage-path)
-zenml_connection_string=$(get_state_value pipeline connection-string)
-k8s_context=$(get_state_value orchestrator k8s-context)
-acr_registry_uri=$(get_state_value container-registry registry-url)
-acr_registry_name=$(get_state_value container-registry registry-name)
-zenserver_url=$(get_state_value pipeline server-url)
-zenserver_username=$(get_state_value pipeline server-username)
-zenserver_password=$(get_state_value pipeline server-password)
-seldon_workload_namespace=$(get_state_value model-deployer workloads-namespace)
-seldon_ingress_host=$(get_state_value model-deployer base-url)
+zenml_storage_path=$(get_state_value storage-path)
+zenml_connection_string=$(get_state_value connection-string)
+k8s_context=$(get_state_value k8s-context)
+acr_registry_uri=$(get_state_value registry-url)
+acr_registry_name=$(get_state_value registry-name)
+zenserver_url=$(get_state_value server-url)
+zenserver_username=$(get_state_value server-username)
+zenserver_password=$(get_state_value server-password)
+seldon_workload_namespace=$(get_state_value workloads-namespace)
+seldon_ingress_host=$(get_state_value base-url)
+
 
 echo "Setting up ZenML..."
 {

--- a/llm/setup.sh
+++ b/llm/setup.sh
@@ -13,26 +13,24 @@ then
 fi
 
 
-get_state_value() {
-    key=$1
-    value=$(sed -n 's/.*"'$key'": "\(.*\)".*/\1/p' .matcha/infrastructure/matcha.state)
-    if [[ -z $value ]]; then
-        echo "Error: The value for '$key' is not found in .matcha/infrastructure/matcha.state!"
-        exit 1
-    fi
-    echo $value
+function get_state_value() {
+    resource_name=$1
+    property=$2
+    json_string=$(matcha get "$resource_name" "$property" --output json --show-sensitive)
+    value=$(echo "$json_string" | sed -n 's/.*"'$property'": "\(.*\)".*/\1/p')
+    echo "$value"
 }
 
-zenml_storage_path=$(get_state_value storage-path)
-zenml_connection_string=$(get_state_value connection-string)
-k8s_context=$(get_state_value k8s-context)
-acr_registry_uri=$(get_state_value registry-url)
-acr_registry_name=$(get_state_value registry-name)
-zenserver_url=$(get_state_value server-url)
-zenserver_username=$(get_state_value server-username)
-zenserver_password=$(get_state_value server-password)
-seldon_workload_namespace=$(get_state_value workloads-namespace)
-seldon_ingress_host=$(get_state_value base-url)
+zenml_storage_path=$(get_state_value pipeline storage-path)
+zenml_connection_string=$(get_state_value pipeline connection-string)
+k8s_context=$(get_state_value orchestrator k8s-context)
+acr_registry_uri=$(get_state_value container-registry registry-url)
+acr_registry_name=$(get_state_value container-registry registry-name)
+zenserver_url=$(get_state_value pipeline server-url)
+zenserver_username=$(get_state_value pipeline server-username)
+zenserver_password=$(get_state_value pipeline server-password)
+seldon_workload_namespace=$(get_state_value model-deployer workloads-namespace)
+seldon_ingress_host=$(get_state_value model-deployer base-url)
 
 
 echo "Setting up ZenML..."

--- a/recommendation/setup.sh
+++ b/recommendation/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+!/bin/bash
 echo "Installing example requirements (see requirements.txt)..."
 {
     pip install -r requirements.txt
@@ -12,29 +12,26 @@ then
     exit 1
 fi
 
-
-get_state_value() {
-    key=$1
-    value=$(sed -n 's/.*"'$key'": "\(.*\)".*/\1/p' .matcha/infrastructure/matcha.state)
-    if [[ -z $value ]]; then
-        echo "Error: The value for '$key' is not found in .matcha/infrastructure/matcha.state!"
-        exit 1
-    fi
-    echo $value
+function get_state_value() {
+    resource_name=$1
+    property=$2
+    json_string=$(matcha get "$resource_name" "$property" --output json --show-sensitive)
+    value=$(echo "$json_string" | sed -n 's/.*"'$property'": "\(.*\)".*/\1/p')
+    echo "$value"
 }
 
-mlflow_tracking_url=$(get_state_value tracking-url)
-zenml_storage_path=$(get_state_value storage-path)
-zenml_connection_string=$(get_state_value connection-string)
-k8s_context=$(get_state_value k8s-context)
-acr_registry_uri=$(get_state_value registry-url)
-acr_registry_name=$(get_state_value registry-name)
-zenserver_url=$(get_state_value server-url)
-zenserver_username=$(get_state_value server-username)
-zenserver_password=$(get_state_value server-password)
-seldon_workload_namespace=$(get_state_value workloads-namespace)
-seldon_ingress_host=$(get_state_value base-url)
-
+mlflow_tracking_url=$(get_state_value experiment-tracker tracking-url)
+zenml_storage_path=$(get_state_value pipeline storage-path)
+zenml_connection_string=$(get_state_value pipeline connection-string)
+k8s_context=$(get_state_value orchestrator k8s-context)
+acr_registry_uri=$(get_state_value container-registry registry-url)
+acr_registry_name=$(get_state_value container-registry registry-name)
+zenserver_url=$(get_state_value pipeline server-url)
+zenserver_username=$(get_state_value pipeline server-username)
+zenserver_password=$(get_state_value pipeline server-password)
+seldon_workload_namespace=$(get_state_value model-deployer workloads-namespace)
+seldon_ingress_host=$(get_state_value model-deployer base-url)
+echo $mlflow_tracking_url
 
 echo "Setting up ZenML..."
 {

--- a/recommendation/setup.sh
+++ b/recommendation/setup.sh
@@ -1,33 +1,6 @@
 #!/bin/bash
 echo "Installing example requirements (see requirements.txt)..."
 {
-    # Install jq on macOS using Homebrew
-    if [[ "$(uname -s)" == "Darwin" ]]; then
-        if ! command -v brew &> /dev/null; then
-            echo "Error: Homebrew is not installed."
-            exit 1
-        fi
-
-        if ! command -v jq &> /dev/null; then
-            echo "Installing jq using Homebrew..."
-            brew install jq
-        fi
-    fi
-
-    # Install jq on Linux using APT
-    if [[ "$(uname -s)" == "Linux" ]]; then
-        if ! command -v apt-get &> /dev/null; then
-            echo "Error: APT is not available."
-            exit 1
-        fi
-
-        if ! command -v jq &> /dev/null; then
-            echo "Installing jq using APT..."
-            sudo apt-get update
-            sudo apt-get install -y jq
-        fi
-    fi
-
     pip install -r requirements.txt
     zenml integration install mlflow azure kubernetes seldon -y
 } >> setup_out.log
@@ -40,25 +13,27 @@ then
 fi
 
 
-function get_state_value() {
-    resource_name=$1
-    property=$2
-    json_string=$(matcha get $resource_name $property --output json --show-sensitive)
-    value=$(echo $json_string | jq -r '."'$resource_name'"."'$property'"')
+get_state_value() {
+    key=$1
+    value=$(sed -n 's/.*"'$key'": "\(.*\)".*/\1/p' .matcha/infrastructure/matcha.state)
+    if [[ -z $value ]]; then
+        echo "Error: The value for '$key' is not found in .matcha/infrastructure/matcha.state!"
+        exit 1
+    fi
     echo $value
 }
 
-mlflow_tracking_url=$(get_state_value experiment-tracker tracking-url)
-zenml_storage_path=$(get_state_value pipeline storage-path)
-zenml_connection_string=$(get_state_value pipeline connection-string)
-k8s_context=$(get_state_value orchestrator k8s-context)
-acr_registry_uri=$(get_state_value container-registry registry-url)
-acr_registry_name=$(get_state_value container-registry registry-name)
-zenserver_url=$(get_state_value pipeline server-url)
-zenserver_username=$(get_state_value pipeline server-username)
-zenserver_password=$(get_state_value pipeline server-password)
-seldon_workload_namespace=$(get_state_value model-deployer workloads-namespace)
-seldon_ingress_host=$(get_state_value model-deployer base-url)
+mlflow_tracking_url=$(get_state_value tracking-url)
+zenml_storage_path=$(get_state_value storage-path)
+zenml_connection_string=$(get_state_value connection-string)
+k8s_context=$(get_state_value k8s-context)
+acr_registry_uri=$(get_state_value registry-url)
+acr_registry_name=$(get_state_value registry-name)
+zenserver_url=$(get_state_value server-url)
+zenserver_username=$(get_state_value server-username)
+zenserver_password=$(get_state_value server-password)
+seldon_workload_namespace=$(get_state_value workloads-namespace)
+seldon_ingress_host=$(get_state_value base-url)
 
 
 echo "Setting up ZenML..."

--- a/recommendation/setup.sh
+++ b/recommendation/setup.sh
@@ -31,7 +31,6 @@ zenserver_username=$(get_state_value pipeline server-username)
 zenserver_password=$(get_state_value pipeline server-password)
 seldon_workload_namespace=$(get_state_value model-deployer workloads-namespace)
 seldon_ingress_host=$(get_state_value model-deployer base-url)
-echo $mlflow_tracking_url
 
 echo "Setting up ZenML..."
 {


### PR DESCRIPTION
This PR removes the dependency on `jq` in the two `setup.sh` scripts for `Recommender` and `LLM` examples. 

We also remove the use of the `matcha get` command for more concise code.