### PR TITLE
[RPD-186] [BUG] Update ZenML stack pointing at the previously provisioned server

### DIFF
--- a/llm/setup.sh
+++ b/llm/setup.sh
@@ -40,6 +40,29 @@ echo "Setting up ZenML..."
 
     zenml init
     zenml connect --url="$zenserver_url" --username="$zenserver_username" --password="$zenserver_password" --no-verify-ssl
+
+    # Clean old stack if it exists
+    cleanup_resources() {
+        local resources=("stack:$1" "secret:az_secret" "container-registry:acr_registry" "experiment-tracker:mlflow_experiment_tracker" "artifact-store:az_store" "orchestrator:k8s_orchestrator" "model-deployer:seldon_deployer" "image-builder:docker_builder")
+
+        # Special case for stack as zenml stack list returns a table which the name of stack is separated into multiple lines
+        if zenml stack list --name="$1" | grep -q "items found for the applied filters."; then
+            echo "Found and removing existing stack named $1"
+            zenml stack set default
+            yes | zenml stack delete "$1"
+        fi
+
+        for resource in "${resources[@]}"; do
+            type="${resource%%:*}" # remove everything after :, inclusive
+            name="${resource#*:}" # remove everything before :, inclusive
+            if zenml "$type" list | grep -q "$name"; then
+                yes | zenml "$type" delete "$name"
+            fi
+        done
+    }
+
+    cleanup_resources "recommendation_example_cloud_stack"
+    
     zenml secret create az_secret --connection_string="$zenml_connection_string"
     zenml container-registry register acr_registry -f azure --uri="$acr_registry_uri"
     zenml artifact-store register az_store -f azure --path="$zenml_storage_path" --authentication_secret=az_secret

--- a/llm/setup.sh
+++ b/llm/setup.sh
@@ -40,6 +40,7 @@ echo "Setting up ZenML..."
 
     zenml init
 
+    # Disconnect from previous server if exists to prevent errors when a new Zen server is being used
     zenml disconnect
 
     zenml connect --url="$zenserver_url" --username="$zenserver_username" --password="$zenserver_password" --no-verify-ssl

--- a/llm/setup.sh
+++ b/llm/setup.sh
@@ -39,29 +39,10 @@ echo "Setting up ZenML..."
     az acr login --name="$acr_registry_name"
 
     zenml init
+
+    zenml disconnect
+
     zenml connect --url="$zenserver_url" --username="$zenserver_username" --password="$zenserver_password" --no-verify-ssl
-
-    # Clean old stack if it exists
-    cleanup_resources() {
-        local resources=("stack:$1" "secret:az_secret" "container-registry:acr_registry" "experiment-tracker:mlflow_experiment_tracker" "artifact-store:az_store" "orchestrator:k8s_orchestrator" "model-deployer:seldon_deployer" "image-builder:docker_builder")
-
-        # Special case for stack as zenml stack list returns a table which the name of stack is separated into multiple lines
-        if zenml stack list --name="$1" | grep -q "items found for the applied filters."; then
-            echo "Found and removing existing stack named $1"
-            zenml stack set default
-            yes | zenml stack delete "$1"
-        fi
-
-        for resource in "${resources[@]}"; do
-            type="${resource%%:*}" # remove everything after :, inclusive
-            name="${resource#*:}" # remove everything before :, inclusive
-            if zenml "$type" list | grep -q "$name"; then
-                yes | zenml "$type" delete "$name"
-            fi
-        done
-    }
-
-    cleanup_resources "recommendation_example_cloud_stack"
     
     zenml secret create az_secret --connection_string="$zenml_connection_string"
     zenml container-registry register acr_registry -f azure --uri="$acr_registry_uri"

--- a/recommendation/setup.sh
+++ b/recommendation/setup.sh
@@ -38,7 +38,8 @@ echo "Setting up ZenML..."
     az acr login --name="$acr_registry_name"
 
     zenml init
-
+    
+    # Disconnect from previous server if exists to prevent errors when a new Zen server is being used
     zenml disconnect
 
     zenml connect --url="$zenserver_url" --username="$zenserver_username" --password="$zenserver_password" --no-verify-ssl
@@ -56,8 +57,7 @@ echo "Setting up ZenML..."
         --kubernetes_namespace=$seldon_workload_namespace \
         --base_url=http://$seldon_ingress_host \
 
-    zenml stack register recommendation_example_cloud_stack -i docker_builder -c acr_registry -e mlflow_experiment_tracker -a az_store -o k8s_orchestrator --model_deployer=seldon_deployer
-    zenml stack set recommendation_example_cloud_stack
+    zenml stack register recommendation_example_cloud_stack -i docker_builder -c acr_registry -e mlflow_experiment_tracker -a az_store -o k8s_orchestrator --model_deployer=seldon_deployer --set
 } >> setup_out.log
 
 echo "ZenML set-up complete."

--- a/recommendation/setup.sh
+++ b/recommendation/setup.sh
@@ -1,9 +1,13 @@
-!/bin/bash
+#!/bin/bash
 echo "Installing example requirements (see requirements.txt)..."
 {
     pip install -r requirements.txt
     zenml integration install mlflow azure kubernetes seldon -y
 } >> setup_out.log
+
+{
+    zenml clean -y
+}
 
 if [[ ! -f .matcha/infrastructure/matcha.state ]]
 then
@@ -53,7 +57,8 @@ echo "Setting up ZenML..."
         --kubernetes_namespace=$seldon_workload_namespace \
         --base_url=http://$seldon_ingress_host \
 
-    zenml stack register recommendation_example_cloud_stack -i docker_builder -c acr_registry -e mlflow_experiment_tracker -a az_store -o k8s_orchestrator --model_deployer=seldon_deployer --set
+    zenml stack register recommendation_example_cloud_stack -i docker_builder -c acr_registry -e mlflow_experiment_tracker -a az_store -o k8s_orchestrator --model_deployer=seldon_deployer
+    zenml stack set recommendation_example_cloud_stack
 } >> setup_out.log
 
 echo "ZenML set-up complete."

--- a/recommendation/setup.sh
+++ b/recommendation/setup.sh
@@ -39,29 +39,9 @@ echo "Setting up ZenML..."
 
     zenml init
 
+    zenml disconnect
+
     zenml connect --url="$zenserver_url" --username="$zenserver_username" --password="$zenserver_password" --no-verify-ssl
-
-    # Clean old stack if it exists
-    cleanup_resources() {
-        local resources=("stack:$1" "secret:az_secret" "container-registry:acr_registry" "experiment-tracker:mlflow_experiment_tracker" "artifact-store:az_store" "orchestrator:k8s_orchestrator" "model-deployer:seldon_deployer" "image-builder:docker_builder")
-
-        # Special case for stack as zenml stack list returns a table which the name of stack is separated into multiple lines
-        if zenml stack list --name="$1" | grep -q "items found for the applied filters."; then
-            echo "Found and removing existing stack named $1"
-            zenml stack set default
-            yes | zenml stack delete "$1"
-        fi
-
-        for resource in "${resources[@]}"; do
-            type="${resource%%:*}" # remove everything after :, inclusive
-            name="${resource#*:}" # remove everything before :, inclusive
-            if zenml "$type" list | grep -q "$name"; then
-                yes | zenml "$type" delete "$name"
-            fi
-        done
-    }
-
-    cleanup_resources "recommendation_example_cloud_stack"
 
     zenml secret create az_secret --connection_string="$zenml_connection_string"
     zenml container-registry register acr_registry -f azure --uri="$acr_registry_uri"


### PR DESCRIPTION
After running matcha provision, the resources that have been provisioned need to be added to the ZenML stack - this is done by the setup.sh script. As part of that setup, ZenML is initialised and if you subsequently destroy those resources, the ZenML stack that’s created as part of the setup.sh still points to the now decommissioned ZenServer. This causes an error when you come to run the example workflows.

To fix this we destroy the current stack and every component within the stack.