### PR TITLE
[RPD-228] [BUG] LLM example fails with missing import error on Nvidia GPU

### DIFF
--- a/llm/pipelines/config_llm_pipeline.yaml
+++ b/llm/pipelines/config_llm_pipeline.yaml
@@ -4,6 +4,8 @@ settings:
     required_integrations:
       - "huggingface"
       - "pytorch"
+    requirements:
+      - accelerate
 steps:
   download_dataset:
     enable_cache: False
@@ -38,7 +40,7 @@ steps:
       # Weight decay
       weight_decay: 0.01
       # Use CUDA for training
-      use_cuda: True
+      use_cuda: False
       # Batch size per device for training
       per_device_train_batch_size: 2
       # Batch size per device for evaluation


### PR DESCRIPTION
On following the same instructions on LLM example readme I came across the error attached in screenshot below.

![image](https://github.com/fuzzylabs/matcha-examples/assets/10743098/b80e5548-b02a-4bda-b687-61ff4bb5cbd2)

It says `accelerate` library is required when using PyTorch as Trainer for huggingface transformer library.

Solution:

- Fix for now is to change `use_cuda` to `False` in `config_llm_pipeline.yaml`
- Add `accelerate` as depedency to requirements.