### PR TITLE
[RPD-277] [BUG] Fix `setup.sh` for the recommendation example

### DIFF
--- a/.github/workflows/ci-llm.yml
+++ b/.github/workflows/ci-llm.yml
@@ -57,9 +57,8 @@ jobs:
       # Install zenml separately due to pyyaml bug : https://github.com/yaml/pyyaml/issues/724
       - name: Install additional dependencies
         run: |
-          source .venv/bin/activate
-          pip install "cython<3" wheel && pip install --no-build-isolation "pyyaml==5.4.1"
-          pip install "zenml==0.36.1"
+          venv/bin/python3 -m pip install "cython<3" wheel && pip install --no-build-isolation "pyyaml==5.4.1"
+          venv/bin/python3 -m pip install "zenml==0.36.1"
 
       - name: Setup ZenML
         run: |

--- a/.github/workflows/ci-llm.yml
+++ b/.github/workflows/ci-llm.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Install dependencies
         if: steps.python_cache.outputs.cache-hit != 'true'
         run: |
+          sed '/zenml/d' recommendation/requirements.txt > recommendation/requirements2.txt
+          mv recommendation/requirements2.txt recommendation/requirements.txt
           if [ -d "venv" ]; then rm -rf venv; fi
 
           python3 -m venv venv 

--- a/.github/workflows/ci-llm.yml
+++ b/.github/workflows/ci-llm.yml
@@ -57,7 +57,7 @@ jobs:
       # Install zenml separately due to pyyaml bug : https://github.com/yaml/pyyaml/issues/724
       - name: Install additional dependencies
         run: |
-          venv/bin/python3 -m pip install "cython<3" wheel && pip install --no-build-isolation "pyyaml==5.4.1"
+          venv/bin/python3 -m pip install "cython<3" wheel setuptools && venv/bin/python3 -m pip install --no-build-isolation "pyyaml==5.4.1"
           venv/bin/python3 -m pip install "zenml==0.36.1"
 
       - name: Setup ZenML

--- a/.github/workflows/ci-llm.yml
+++ b/.github/workflows/ci-llm.yml
@@ -52,6 +52,13 @@ jobs:
 
           venv/bin/python3 -m pip install -r llm/requirements.txt
 
+      # Install zenml separately due to pyyaml bug : https://github.com/yaml/pyyaml/issues/724
+      - name: Install additional dependencies
+        run: |
+          source .venv/bin/activate
+          pip install "cython<3" wheel && pip install --no-build-isolation "pyyaml==5.4.1"
+          pip install "zenml==0.36.1"
+
       - name: Setup ZenML
         run: |
           source venv/bin/activate

--- a/.github/workflows/ci-llm.yml
+++ b/.github/workflows/ci-llm.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         if: steps.python_cache.outputs.cache-hit != 'true'
         run: |
-          sed '/zenml/d' recommendation/requirements.txt > recommendation/requirements2.txt
+          sed 'zenmld' recommendation/requirements.txt > recommendation/requirements2.txt
           mv recommendation/requirements2.txt recommendation/requirements.txt
           if [ -d "venv" ]; then rm -rf venv; fi
 

--- a/.github/workflows/ci-llm.yml
+++ b/.github/workflows/ci-llm.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Install dependencies
         if: steps.python_cache.outputs.cache-hit != 'true'
         run: |
-          sed 'zenmld' recommendation/requirements.txt > recommendation/requirements2.txt
-          mv recommendation/requirements2.txt recommendation/requirements.txt
+          sed '/zenml/d' llm/requirements.txt > llm/requirements2.txt
+          mv llm/requirements2.txt llm/requirements.txt
           if [ -d "venv" ]; then rm -rf venv; fi
 
           python3 -m venv venv 

--- a/.github/workflows/ci-llm.yml
+++ b/.github/workflows/ci-llm.yml
@@ -57,8 +57,9 @@ jobs:
       # Install zenml separately due to pyyaml bug : https://github.com/yaml/pyyaml/issues/724
       - name: Install additional dependencies
         run: |
-          venv/bin/python3 -m pip install "cython<3" wheel setuptools && venv/bin/python3 -m pip install --no-build-isolation "pyyaml==5.4.1"
-          venv/bin/python3 -m pip install "zenml==0.36.1"
+          source venv/bin/activate
+          pip install "cython<3" wheel setuptools && pip install --no-build-isolation "pyyaml==5.4.1"
+          pip install "zenml[server]==0.36.1"
 
       - name: Setup ZenML
         run: |

--- a/.github/workflows/ci-llm.yml
+++ b/.github/workflows/ci-llm.yml
@@ -46,8 +46,6 @@ jobs:
       - name: Install dependencies
         if: steps.python_cache.outputs.cache-hit != 'true'
         run: |
-          sed '/zenml/d' llm/requirements.txt > llm/requirements2.txt
-          mv llm/requirements2.txt llm/requirements.txt
           if [ -d "venv" ]; then rm -rf venv; fi
 
           python3 -m venv venv 

--- a/.github/workflows/ci-recommendation.yml
+++ b/.github/workflows/ci-recommendation.yml
@@ -57,9 +57,8 @@ jobs:
       # Install zenml separately due to pyyaml bug : https://github.com/yaml/pyyaml/issues/724
       - name: Install additional dependencies
         run: |
-          source .venv/bin/activate
-          pip install "cython<3" wheel && pip install --no-build-isolation "pyyaml==5.4.1"
-          pip install "zenml==0.36.1"
+          venv/bin/python3 -m pip install "cython<3" wheel && pip install --no-build-isolation "pyyaml==5.4.1"
+          venv/bin/python3 -m pip install "zenml==0.36.1"
 
       - name: Setup ZenML
         run: |

--- a/.github/workflows/ci-recommendation.yml
+++ b/.github/workflows/ci-recommendation.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Install dependencies
         if: steps.python_cache.outputs.cache-hit != 'true'
         run: |
+          sed '/zenml/d' recommendation/requirements.txt > recommendation/requirements2.txt
+          mv recommendation/requirements2.txt recommendation/requirements.txt
           if [ -d "venv" ]; then rm -rf venv; fi
 
           python3 -m venv venv 

--- a/.github/workflows/ci-recommendation.yml
+++ b/.github/workflows/ci-recommendation.yml
@@ -57,7 +57,7 @@ jobs:
       # Install zenml separately due to pyyaml bug : https://github.com/yaml/pyyaml/issues/724
       - name: Install additional dependencies
         run: |
-          venv/bin/python3 -m pip install "cython<3" wheel && pip install --no-build-isolation "pyyaml==5.4.1"
+          venv/bin/python3 -m pip install "cython<3" wheel setuptools && venv/bin/python3 -m pip install --no-build-isolation "pyyaml==5.4.1"
           venv/bin/python3 -m pip install "zenml==0.36.1"
 
       - name: Setup ZenML

--- a/.github/workflows/ci-recommendation.yml
+++ b/.github/workflows/ci-recommendation.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         if: steps.python_cache.outputs.cache-hit != 'true'
         run: |
-          sed '/zenml/d' recommendation/requirements.txt > recommendation/requirements2.txt
+          sed 'zenmld' recommendation/requirements.txt > recommendation/requirements2.txt
           mv recommendation/requirements2.txt recommendation/requirements.txt
           if [ -d "venv" ]; then rm -rf venv; fi
 

--- a/.github/workflows/ci-recommendation.yml
+++ b/.github/workflows/ci-recommendation.yml
@@ -52,6 +52,13 @@ jobs:
 
           venv/bin/python3 -m pip install -r recommendation/requirements.txt
 
+      # Install zenml separately due to pyyaml bug : https://github.com/yaml/pyyaml/issues/724
+      - name: Install additional dependencies
+        run: |
+          source .venv/bin/activate
+          pip install "cython<3" wheel && pip install --no-build-isolation "pyyaml==5.4.1"
+          pip install "zenml==0.36.1"
+
       - name: Setup ZenML
         run: |
           source venv/bin/activate

--- a/.github/workflows/ci-recommendation.yml
+++ b/.github/workflows/ci-recommendation.yml
@@ -60,6 +60,7 @@ jobs:
           source venv/bin/activate
           pip install "cython<3" wheel setuptools && pip install --no-build-isolation "pyyaml==5.4.1"
           pip install "zenml==0.36.1"
+          pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple "scikit-surprise==1.1.3"
 
       - name: Setup ZenML
         run: |

--- a/.github/workflows/ci-recommendation.yml
+++ b/.github/workflows/ci-recommendation.yml
@@ -57,8 +57,9 @@ jobs:
       # Install zenml separately due to pyyaml bug : https://github.com/yaml/pyyaml/issues/724
       - name: Install additional dependencies
         run: |
-          venv/bin/python3 -m pip install "cython<3" wheel setuptools && venv/bin/python3 -m pip install --no-build-isolation "pyyaml==5.4.1"
-          venv/bin/python3 -m pip install "zenml==0.36.1"
+          source venv/bin/activate
+          pip install "cython<3" wheel setuptools && pip install --no-build-isolation "pyyaml==5.4.1"
+          pip install "zenml==0.36.1"
 
       - name: Setup ZenML
         run: |

--- a/.github/workflows/ci-recommendation.yml
+++ b/.github/workflows/ci-recommendation.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         if: steps.python_cache.outputs.cache-hit != 'true'
         run: |
-          sed 'zenmld' recommendation/requirements.txt > recommendation/requirements2.txt
+          sed '/zenml/d' recommendation/requirements.txt > recommendation/requirements2.txt
           mv recommendation/requirements2.txt recommendation/requirements.txt
           if [ -d "venv" ]; then rm -rf venv; fi
 

--- a/llm/README.md
+++ b/llm/README.md
@@ -63,8 +63,6 @@ This will install the requirements for the example (see [requirements.txt](requi
 ./setup.sh
 ```
 
-> Note that in the `setup.sh` script we also install [`jq`](https://stedolan.github.io/jq/) to your system using [Homebrew](https://brew.sh/) for MacOS users and `apt-get` for Linux users. If you are a MacOS user and do not have Homebrew installed you will need to install it yourself.
-
 > You may need to give the `setup.sh` file the correct permissions to run, if so then do the following: `chmod +x setup.sh`.
 
 ## ▶️ Running the example

--- a/recommendation/README.md
+++ b/recommendation/README.md
@@ -73,8 +73,6 @@ This will install the requirements for the example (see [requirements.txt](requi
 ./setup.sh
 ```
 
-> Note that in the `setup.sh` script we also install [`jq`](https://stedolan.github.io/jq/) to your system using [Homebrew](https://brew.sh/) for MacOS users and `apt-get` for Linux users. If you are a MacOS user and do not have Homebrew installed you will need to install it yourself.
-
 > You may need to give the `setup.sh` file the correct permissions to run, if so then do the following: `chmod +x setup.sh`.
 
 ## ▶️ Running the example

--- a/recommendation/requirements.txt
+++ b/recommendation/requirements.txt
@@ -1,3 +1,2 @@
-scikit-surprise==1.1.3
-zenml[server]==0.36.1
+zenml==0.36.1
 pytest==7.2.2

--- a/recommendation/requirements.txt
+++ b/recommendation/requirements.txt
@@ -1,4 +1,3 @@
-wheel==0.40.0
 zenml[server]==0.36.1
 pytest==7.2.2
 scikit-surprise==1.1.3

--- a/recommendation/requirements.txt
+++ b/recommendation/requirements.txt
@@ -1,3 +1,1 @@
-scikit-surprise==1.1.3
-zenml[server]==0.36.1
 pytest==7.2.2

--- a/recommendation/requirements.txt
+++ b/recommendation/requirements.txt
@@ -1,3 +1,3 @@
+scikit-surprise==1.1.3
 zenml[server]==0.36.1
 pytest==7.2.2
-scikit-surprise==1.1.3

--- a/recommendation/requirements.txt
+++ b/recommendation/requirements.txt
@@ -1,2 +1,4 @@
-zenml==0.36.1
+wheel==0.40.0
+zenml[server]==0.36.1
 pytest==7.2.2
+scikit-surprise==1.1.3

--- a/recommendation/setup.sh
+++ b/recommendation/setup.sh
@@ -2,6 +2,9 @@
 echo "Installing example requirements (see requirements.txt)..."
 {
     pip install -r requirements.txt
+    pip install "cython<3" wheel setuptools && pip install --no-build-isolation "pyyaml==5.4.1"
+    pip install "zenml[server]==0.36.1"
+    pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple "scikit-surprise==1.1.3"
     zenml integration install mlflow azure kubernetes seldon -y
 } >> setup_out.log
 

--- a/recommendation/setup.sh
+++ b/recommendation/setup.sh
@@ -2,6 +2,7 @@
 echo "Installing example requirements (see requirements.txt)..."
 {
     pip install -r requirements.txt
+    pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple "scikit-surprise==1.1.3"
     zenml integration install mlflow azure kubernetes seldon -y
 } >> setup_out.log
 

--- a/recommendation/setup.sh
+++ b/recommendation/setup.sh
@@ -2,7 +2,6 @@
 echo "Installing example requirements (see requirements.txt)..."
 {
     pip install -r requirements.txt
-    pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple "scikit-surprise==1.1.3"
     zenml integration install mlflow azure kubernetes seldon -y
 } >> setup_out.log
 


### PR DESCRIPTION
`scikit-surprise` does not provide wheels for installation. Therefore when using a `pyproject.toml` based virtual environment it will not be able to install `scikit-surprise` due to not adhering to PEP 517 installing standards. This updates the requirements to install the `scikit-surprise` library differently. 

This PR also updates the CI to fix a bug introduced by Cython3 with pyyaml, described here: https://github.com/yaml/pyyaml/issues/724